### PR TITLE
support --no-persist. fixes #14

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var mime = require('mime')
 var minimist = require('minimist')
 var TimeoutStream = require('through-timeout')
 var cbTimeout = require('callback-timeout')
+var ram = require('random-access-memory')
 
 var argv = minimist(process.argv.slice(2), {
   alias: {port: 'p', cacheSize: 'cache-size'},
@@ -45,6 +46,7 @@ sw.once('error', function () {
 })
 
 var cache = lru(argv.cacheSize || 100)
+var file = argv.persist === false ? ram : undefined
 
 cache.on('evict', function (item) {
   sw.leave(Buffer(item.key, 'hex'))
@@ -58,7 +60,7 @@ var server = http.createServer(function (req, res) {
 
   var archive = cache.get(dat.discoveryKey)
   if (!archive) {
-    archive = drive.createArchive(dat.key)
+    archive = drive.createArchive(dat.key, {file: file})
     cache.set(archive.discoveryKey.toString('hex'), archive)
     sw.join(archive.discoveryKey)
   }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "hyperdrive": "^6.3.0",
     "level": "^1.4.0",
     "lru": "^3.0.0",
-    "memdb": "^1.3.1",
     "mime": "^1.3.4",
     "minimist": "^1.2.0",
     "pump": "^1.0.1",
+    "random-access-memory": "^1.1.0",
     "through-timeout": "^1.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
`dat.haus --no-persist` makes it use random-access-memory to store data
