### PR TITLE
Use hyperdrive-http module (#17)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+var http = require('http')
 var level = require('level')
 var lru = require('lru')
 var hyperdrive = require('hyperdrive')
@@ -47,7 +48,14 @@ cache.on('evict', function (item) {
   item.value.close()
 })
 
-hyperdriveHttp(getArchive, argv)
+var server = http.createServer()
+
+var onrequest = hyperdriveHttp(getArchive)
+server.on('request', onrequest)
+
+server.listen(argv.port, function () {
+  console.log('Server is listening on port ' + argv.port)
+})
 
 function getArchive(dat, cb) {
   var archive = cache.get(dat.discoveryKey)

--- a/index.js
+++ b/index.js
@@ -2,21 +2,14 @@
 
 'use strict'
 
-var http = require('http')
-var crypto = require('crypto')
-var pump = require('pump')
 var level = require('level')
 var lru = require('lru')
-var JSONStream = require('JSONStream')
 var hyperdrive = require('hyperdrive')
 var swarm = require('discovery-swarm')
 var defaults = require('datland-swarm-defaults')
-var mime = require('mime')
-var rangeParser = require('range-parser')
 var minimist = require('minimist')
-var TimeoutStream = require('through-timeout')
-var cbTimeout = require('callback-timeout')
 var ram = require('random-access-memory')
+var hyperdriveHttp = require('hyperdrive-http')
 
 var argv = minimist(process.argv.slice(2), {
   alias: {port: 'p', cacheSize: 'cache-size'},
@@ -54,72 +47,14 @@ cache.on('evict', function (item) {
   item.value.close()
 })
 
-var server = http.createServer(function (req, res) {
-  var dat = parse(req.url)
+hyperdriveHttp(getArchive, argv)
 
-  if (!dat) return onerror(404, res)
-
+function getArchive(dat, cb) {
   var archive = cache.get(dat.discoveryKey)
   if (!archive) {
     archive = drive.createArchive(dat.key, {file: file})
     cache.set(archive.discoveryKey.toString('hex'), archive)
     sw.join(archive.discoveryKey)
   }
-
-  if (!dat.filename) {
-    var src = archive.list({live: false})
-    var timeout = TimeoutStream({
-      objectMode: true,
-      duration: 10000
-    }, () => {
-      onerror(404, res)
-      src.destroy()
-    })
-    var stringify = JSONStream.stringify('[', ',', ']\n', 2)
-    pump(src, timeout, stringify, res)
-  }
-
-  archive.get(dat.filename, cbTimeout((err, entry) => {
-    if (err && err.code === 'ETIMEOUT') return onerror(404, res)
-    if (err || !entry || entry.type !== 'file') return onerror(404, res)
-
-    var range = req.headers.range && rangeParser(entry.length, req.headers.range)[0]
-
-    res.setHeader('Access-Ranges', 'bytes')
-    res.setHeader('Content-Type', mime.lookup(dat.filename))
-
-    if (!range || range < 0) {
-      res.setHeader('Content-Length', entry.length)
-      if (req.method === 'HEAD') return res.end()
-      pump(archive.createFileReadStream(entry), res)
-    } else {
-      res.statusCode = 206
-      res.setHeader('Content-Length', range.end - range.start + 1)
-      res.setHeader('Content-Range', 'bytes ' + range.start + '-' + range.end + '/' + entry.length)
-      if (req.method === 'HEAD') return res.end()
-      pump(archive.createFileReadStream(entry, {start: range.start, end: range.end + 1}), res)
-    }
-  }, 10000))
-})
-
-server.listen(argv.port, function () {
-  console.log('Server is listening on port ' + argv.port)
-})
-
-function onerror (status, res) {
-  res.statusCode = status
-  res.end()
-}
-
-function parse (url) {
-  var key = url.slice(1, 65)
-  if (!/^[0-9a-f]{64}$/.test(key)) return null
-
-  var filename = url.slice(66)
-
-  return {
-    key: key,
-    discoveryKey: crypto.createHmac('sha256', Buffer(key, 'hex')).update('hypercore').digest('hex'),
-    filename: filename
-  }
+  cb(null, archive)
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "datland-swarm-defaults": "^1.0.0",
     "discovery-swarm": "^4.0.0",
     "hyperdrive": "^6.3.0",
+    "hyperdrive-http": "^1.0.0",
     "level": "^1.4.0",
     "lru": "^3.0.0",
     "mime": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "datland-swarm-defaults": "^1.0.0",
     "discovery-swarm": "^4.0.0",
     "hyperdrive": "^6.3.0",
-    "hyperdrive-http": "^1.0.0",
+    "hyperdrive-http": "^2.0.0",
     "level": "^1.4.0",
     "lru": "^3.0.0",
     "mime": "^1.3.4",


### PR DESCRIPTION
Uses [hyperdrive-http module](https://github.com/joehand/hyperdrive-http).

Let me know if that API on hyperdrive-http makes sense. It works for both dat.haus and the CLI right now but not sure its the easiest to understand.
